### PR TITLE
feat!: store parent in containers and cross-references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ kover {
 
 subprojects {
     group = "com.larsreimann"
-    version = "1.0.0"
+    version = "2.0.0"
 
     repositories {
         mavenCentral()

--- a/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
+++ b/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
@@ -157,7 +157,7 @@ open class ModelNode {
     inner class ContainmentReference<T : ModelNode>(node: T?) : Container<T>() {
 
         /**
-         * The node that is currently referenced or `null`.
+         * The node that is currently contained or `null`.
          */
         var node: T? = null
             set(value) {
@@ -378,6 +378,9 @@ open class ModelNode {
         var handleMove: CrossReference<T>.(from: Location, to: Location) -> Unit = { _, _ -> }
     ) {
 
+        /**
+         * The node that is currently referenced or `null`.
+         */
         var node: T? = null
             set(value) {
                 if (field == value) {

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentListTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentListTest.kt
@@ -5,6 +5,7 @@ import com.larsreimann.modeling.util.NamedNode
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -27,6 +28,11 @@ class ContainmentListTest {
     fun `constructor should correctly link initial values`() {
         innerNode.shouldBeLocatedAt(root, root.children)
         root.children.shouldContainExactly(innerNode)
+    }
+
+    @Test
+    fun `should store parent`() {
+        root.children.parent shouldBe root
     }
 
     @Test

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentReferenceTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentReferenceTest.kt
@@ -2,6 +2,7 @@ package com.larsreimann.modeling
 
 import com.larsreimann.modeling.assertions.shouldBeLocatedAt
 import com.larsreimann.modeling.assertions.shouldBeReleased
+import com.larsreimann.modeling.util.NamedNode
 import io.kotest.assertions.throwables.shouldNotThrowUnit
 import io.kotest.matchers.concurrent.shouldCompleteWithin
 import io.kotest.matchers.nulls.shouldBeNull
@@ -12,7 +13,7 @@ import java.util.concurrent.TimeUnit
 
 class ContainmentReferenceTest {
 
-    private class Root(child: ModelNode, someOtherChild: ModelNode) : ModelNode() {
+    private class Root(child: ModelNode, someOtherChild: ModelNode) : NamedNode("root") {
         val child = ContainmentReference(child)
         val someOtherChild = ContainmentReference(someOtherChild)
     }
@@ -23,8 +24,8 @@ class ContainmentReferenceTest {
 
     @BeforeEach
     fun resetTestData() {
-        innerNode = ModelNode()
-        someOtherInnerNode = ModelNode()
+        innerNode = NamedNode("innerNode")
+        someOtherInnerNode = NamedNode("someOtherInnerNode")
         root = Root(innerNode, someOtherInnerNode)
     }
 
@@ -32,6 +33,11 @@ class ContainmentReferenceTest {
     fun `constructor should correctly link initial value`() {
         innerNode.shouldBeLocatedAt(root, root.child)
         root.child.node shouldBe innerNode
+    }
+
+    @Test
+    fun `should store parent`() {
+        root.child.parent shouldBe root
     }
 
     @Test

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/CrossReferenceTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/CrossReferenceTest.kt
@@ -2,55 +2,60 @@
 
 package com.larsreimann.modeling
 
+import com.larsreimann.modeling.util.NamedNode
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.sequences.shouldBeEmpty
-import io.kotest.matchers.sequences.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class CrossReferenceTest {
 
-    private class Root(child: ModelNode) : ModelNode() {
+    private class Root(child: ModelNode, crossReference: ModelNode) : NamedNode("root") {
         var child by ContainmentReference(child)
+        var crossReference = CrossReference(crossReference)
     }
 
     private lateinit var innerNode: ModelNode
     private lateinit var someOtherInnerNode: ModelNode
     private lateinit var root: Root
-    private lateinit var crossReference: ModelNode.CrossReference<ModelNode>
 
     @BeforeEach
     fun resetTestData() {
-        innerNode = ModelNode()
-        someOtherInnerNode = ModelNode()
-        root = Root(innerNode)
-        crossReference = ModelNode.CrossReference(innerNode)
+        innerNode = NamedNode("innerNode")
+        someOtherInnerNode = NamedNode("someOtherInnerNode")
+        root = Root(innerNode, innerNode)
+    }
+
+    @Test
+    fun `should store parent`() {
+        root.crossReference.parent shouldBe root
     }
 
     @Test
     fun `setter should register cross-reference on new node`() {
-        crossReference.node = someOtherInnerNode
-        someOtherInnerNode.crossReferences().shouldContainExactly(crossReference)
+        root.crossReference.node = someOtherInnerNode
+        someOtherInnerNode.crossReferences().toList().shouldContainExactly(root.crossReference)
     }
 
     @Test
     fun `setter should update the value`() {
-        crossReference.node = someOtherInnerNode
-        crossReference.node shouldBe someOtherInnerNode
+        root.crossReference.node = someOtherInnerNode
+        root.crossReference.node shouldBe someOtherInnerNode
     }
 
     @Test
     fun `setter should deregister cross-reference on old node`() {
-        crossReference.node = someOtherInnerNode
+        root.crossReference.node = someOtherInnerNode
         innerNode.crossReferences().shouldBeEmpty()
     }
 
     @Test
     fun `onMove should be called when the node is moved`() {
         var wasCalled = false
-        crossReference = ModelNode.CrossReference(innerNode) { _, _ -> wasCalled = true }
+        root.crossReference.handleMove = { _, _ -> wasCalled = true }
         innerNode.release()
 
         wasCalled.shouldBeTrue()
@@ -59,7 +64,7 @@ class CrossReferenceTest {
     @Test
     fun `onMove should not called when the node was not moved`() {
         var wasCalled = false
-        crossReference = ModelNode.CrossReference(someOtherInnerNode) { _, _ -> wasCalled = true }
+        root.crossReference.handleMove = { _, _ -> wasCalled = true }
         someOtherInnerNode.release()
 
         wasCalled.shouldBeFalse()

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/MutableContainmentListTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/MutableContainmentListTest.kt
@@ -5,6 +5,7 @@ import com.larsreimann.modeling.assertions.shouldBeReleased
 import com.larsreimann.modeling.util.NamedNode
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -30,6 +31,11 @@ class MutableContainmentListTest {
     fun `constructor should correctly link initial values`() {
         innerNode.shouldBeLocatedAt(root, root.children)
         root.children.shouldContainExactly(innerNode)
+    }
+
+    @Test
+    fun `should store parent`() {
+        root.children.parent shouldBe root
     }
 
     @Test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "model-utils",
+    "name": "workspace",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
### Summary of Changes

* Store parent node in containers and cross-references

This is a breaking change since `ModelNode.CrossReference` is now an inner class.
