### PR TITLE
feat: unified way to access children of container

### DIFF
--- a/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
+++ b/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
@@ -76,6 +76,11 @@ open class ModelNode {
         abstract val parent: ModelNode
 
         /**
+         * The [ModelNode]s within this container.
+         */
+        abstract fun children(): Sequence<T>
+
+        /**
          * Releases the subtree that has this node as root. If this container does not contain the node nothing should
          * happen. Otherwise, the following links need to be removed:
          *   - From the container to the node
@@ -185,6 +190,10 @@ open class ModelNode {
 
         override val parent = this@ModelNode
 
+        override fun children() = sequence {
+            node?.let { yield(it) }
+        }
+
         override fun releaseNode(node: ModelNode) {
             if (this.node == node) {
                 this.node = null
@@ -222,6 +231,10 @@ open class ModelNode {
 
         override val parent = this@ModelNode
 
+        override fun children() = sequence {
+            yieldAll(delegate)
+        }
+
         override fun releaseNode(node: ModelNode) {
             if (node in delegate) {
                 throw IllegalStateException("Node is contained in an immutable list and cannot be released.")
@@ -247,6 +260,10 @@ open class ModelNode {
         }
 
         override val parent = this@ModelNode
+
+        override fun children() = sequence {
+            yieldAll(delegate)
+        }
 
         override fun releaseNode(node: ModelNode) {
             this.remove(node)

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentListTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentListTest.kt
@@ -5,6 +5,7 @@ import com.larsreimann.modeling.util.NamedNode
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.sequences.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -33,6 +34,11 @@ class ContainmentListTest {
     @Test
     fun `should store parent`() {
         root.children.parent shouldBe root
+    }
+
+    @Test
+    fun `children should list children `() {
+        root.children.children().shouldContainExactly(innerNode)
     }
 
     @Test

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentReferenceTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/ContainmentReferenceTest.kt
@@ -6,6 +6,8 @@ import com.larsreimann.modeling.util.NamedNode
 import io.kotest.assertions.throwables.shouldNotThrowUnit
 import io.kotest.matchers.concurrent.shouldCompleteWithin
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.sequences.shouldBeEmpty
+import io.kotest.matchers.sequences.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -38,6 +40,17 @@ class ContainmentReferenceTest {
     @Test
     fun `should store parent`() {
         root.child.parent shouldBe root
+    }
+
+    @Test
+    fun `children should list child if it is not null`() {
+        root.child.children().shouldContainExactly(innerNode)
+    }
+
+    @Test
+    fun `children should not list child if it is null`() {
+        root.child.node = null
+        root.child.children().shouldBeEmpty()
     }
 
     @Test

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/MutableContainmentListTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/MutableContainmentListTest.kt
@@ -5,6 +5,7 @@ import com.larsreimann.modeling.assertions.shouldBeReleased
 import com.larsreimann.modeling.util.NamedNode
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.sequences.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,6 +37,11 @@ class MutableContainmentListTest {
     @Test
     fun `should store parent`() {
         root.children.parent shouldBe root
+    }
+
+    @Test
+    fun `children should list children `() {
+        root.children.children().shouldContainExactly(innerNode)
     }
 
     @Test


### PR DESCRIPTION
Closes #3.

### Summary of Changes

* Method `children` on containers to access children in a unified manner