### PR TITLE
refactor!: improve interface of ModelNode class

### DIFF
--- a/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
+++ b/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KProperty
 /**
  * A node in a tree. It has references to its parent and its children.
  */
-open class ModelNode {
+abstract class ModelNode {
 
     /**
      * Parent and container of this node in the tree.
@@ -28,7 +28,7 @@ open class ModelNode {
     /**
      * Cross-references to this node. They get notified whenever this node is moved.
      */
-    private val crossReferences = mutableListOf<CrossReference<*>>()
+    private val crossReferencesToThis = mutableListOf<CrossReference<*>>()
 
     /**
      * Whether this node is the root of the tree.
@@ -40,12 +40,12 @@ open class ModelNode {
     /**
      * The child nodes of this node.
      */
-    open fun children() = emptySequence<ModelNode>()
+    abstract fun children(): Sequence<ModelNode>
 
     /**
      * Cross-references to this node. They get notified whenever this node is moved.
      */
-    fun crossReferences() = crossReferences.toList().asSequence()
+    fun crossReferencesToThis() = crossReferencesToThis.toList().asSequence()
 
     /**
      * Releases the subtree that has this node as root.
@@ -62,7 +62,7 @@ open class ModelNode {
         val newLocation = Location(newParent, newContainer)
         this.container = newContainer
 
-        crossReferences.forEach { it.onMove(oldLocation, newLocation) }
+        crossReferencesToThis.forEach { it.onMove(oldLocation, newLocation) }
     }
 
     /**
@@ -404,9 +404,9 @@ open class ModelNode {
                     return
                 }
 
-                field?.crossReferences?.remove(this)
+                field?.crossReferencesToThis?.remove(this)
                 field = value
-                value?.crossReferences?.add(this)
+                value?.crossReferencesToThis?.add(this)
             }
 
         init {

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/CrossReferenceTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/CrossReferenceTest.kt
@@ -37,7 +37,7 @@ class CrossReferenceTest {
     @Test
     fun `setter should register cross-reference on new node`() {
         root.crossReference.node = someOtherInnerNode
-        someOtherInnerNode.crossReferences().toList().shouldContainExactly(root.crossReference)
+        someOtherInnerNode.crossReferencesToThis().toList().shouldContainExactly(root.crossReference)
     }
 
     @Test
@@ -49,7 +49,7 @@ class CrossReferenceTest {
     @Test
     fun `setter should deregister cross-reference on old node`() {
         root.crossReference.node = someOtherInnerNode
-        innerNode.crossReferences().shouldBeEmpty()
+        innerNode.crossReferencesToThis().shouldBeEmpty()
     }
 
     @Test
@@ -62,7 +62,7 @@ class CrossReferenceTest {
     }
 
     @Test
-    fun `onMove should not called when the node was not moved`() {
+    fun `onMove should not be called when the node was not moved`() {
         var wasCalled = false
         root.crossReference.handleMove = { _, _ -> wasCalled = true }
         someOtherInnerNode.release()

--- a/modeling-core/src/test/kotlin/com/larsreimann/modeling/ModelNodeTest.kt
+++ b/modeling-core/src/test/kotlin/com/larsreimann/modeling/ModelNodeTest.kt
@@ -3,6 +3,7 @@
 package com.larsreimann.modeling
 
 import com.larsreimann.modeling.assertions.shouldBeReleased
+import com.larsreimann.modeling.util.TestNode
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.sequences.shouldBeEmpty
@@ -12,13 +13,13 @@ class ModelNodeTest {
 
     @Test
     fun `isRoot() should be true by default`() {
-        ModelNode().isRoot().shouldBeTrue()
+        TestNode().isRoot().shouldBeTrue()
     }
 
     @Test
     fun `isRoot() should indicate whether the node has a parent`() {
-        val innerNode = ModelNode()
-        val root = object : ModelNode() {
+        val innerNode = TestNode()
+        val root = object : TestNode() {
             val child = ContainmentReference(innerNode)
         }
 
@@ -28,13 +29,13 @@ class ModelNodeTest {
 
     @Test
     fun `children() should be empty by default`() {
-        ModelNode().children().shouldBeEmpty()
+        TestNode().children().shouldBeEmpty()
     }
 
     @Test
     fun `release() should set parent and container to null`() {
-        val innerNode = ModelNode()
-        val root = object : ModelNode() {
+        val innerNode = TestNode()
+        val root = object : TestNode() {
             val child = ContainmentReference(innerNode)
         }
 

--- a/modeling-core/src/testFixtures/kotlin/com/larsreimann/modeling/util/NamedNode.kt
+++ b/modeling-core/src/testFixtures/kotlin/com/larsreimann/modeling/util/NamedNode.kt
@@ -1,8 +1,6 @@
 package com.larsreimann.modeling.util
 
-import com.larsreimann.modeling.ModelNode
-
-open class NamedNode(private val name: String) : ModelNode() {
+open class NamedNode(private val name: String) : TestNode() {
     override fun toString(): String {
         return name
     }

--- a/modeling-core/src/testFixtures/kotlin/com/larsreimann/modeling/util/TestNode.kt
+++ b/modeling-core/src/testFixtures/kotlin/com/larsreimann/modeling/util/TestNode.kt
@@ -1,0 +1,7 @@
+package com.larsreimann.modeling.util
+
+import com.larsreimann.modeling.ModelNode
+
+open class TestNode : ModelNode() {
+    override fun children() = emptySequence<ModelNode>()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-    "name": "workspace",
+    "name": "modeling",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
+            "name": "modeling",
             "devDependencies": {
                 "@lars-reimann/prettier-config": "^5.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "modeling",
     "private": true,
     "devDependencies": {
         "@lars-reimann/prettier-config": "^5.0.0"


### PR DESCRIPTION
### Summary of Changes

BREAKING CHANGES:

- `ModelNode` is now abstract. **Explanation:** This enforces the desired usage of creating subclasses of `ModelNode` rather than trying to use `ModelNode` directly.
- Make `children` abstract. **Explanation:** The previous default behavior was only correct for leaf nodes and I frequently forgot to override the method for inner nodes. Now the compiler enforces overriding the method. Users can still put a default implementation into some part of their class hierarchy if they want the previous behavior back.
- Rename `crossReferences` to `crossReferencesToThis`. **Explanation:** This makes it obvious the function returns cross-references that *point to the node* rather than cross-references that *start at the node*.
