### PR TITLE
fix: don't override `children` method in `ModelNode` anymore

### DIFF
--- a/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
+++ b/modeling-core/src/main/kotlin/com.larsreimann.modeling/ModelNode.kt
@@ -33,11 +33,6 @@ abstract class ModelNode : Traversable {
     private val crossReferencesToThis = mutableListOf<CrossReference<*>>()
 
     /**
-     * The child nodes of this node.
-     */
-    abstract override fun children(): Sequence<ModelNode>
-
-    /**
      * Cross-references to this node. They get notified whenever this node is moved.
      */
     fun crossReferencesToThis() = crossReferencesToThis.toList().asSequence()


### PR DESCRIPTION
### Summary of Changes

Previously, the `children` method was overridden in `ModelNode` to restrict the return type to `Sequence<ModelNode>`. However, this sequence was rarely more useful than `Sequence<Traversable>` and still had to be filtered by `filterIsInstance`. The implementation also had the big downside that classes that extend `ModelNode` and implement an interface that extends `Traversable` had to implement their own version of `children`, even if the interface already provided it.